### PR TITLE
Change validate to throw an exception on direct error

### DIFF
--- a/lang/py/src/avro/io.py
+++ b/lang/py/src/avro/io.py
@@ -5,9 +5,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,7 +34,7 @@ uses the following mapping:
   * Schema longs are implemented as long.
   * Schema floats are implemented as float.
   * Schema doubles are implemented as float.
-  * Schema booleans are implemented as bool. 
+  * Schema booleans are implemented as bool.
 """
 import struct
 from avro import schema
@@ -81,9 +81,9 @@ STRUCT_CRC32 = struct_class('>I')   # big-endian unsigned int
 class AvroTypeException(schema.AvroException):
   """Raised when datum is not an example of schema."""
   def __init__(self, expected_schema, datum):
-    pretty_expected = json.dumps(json.loads(str(expected_schema)), indent=2)
+    # pretty_expected = json.dumps(json.loads(str(expected_schema)), indent=2)
     fail_msg = "The datum %s is not an example of the schema %s"\
-               % (datum, pretty_expected)
+               % (datum, str(expected_schema))
     schema.AvroException.__init__(self, fail_msg)
 
 class SchemaResolutionException(schema.AvroException):
@@ -101,41 +101,56 @@ class SchemaResolutionException(schema.AvroException):
 def validate(expected_schema, datum):
   """Determine if a python datum is an instance of a schema."""
   schema_type = expected_schema.type
+  valid = False
+
   if schema_type == 'null':
-    return datum is None
+    valid = (datum is None)
   elif schema_type == 'boolean':
-    return isinstance(datum, bool)
+    valid = isinstance(datum, bool)
   elif schema_type == 'string':
-    return isinstance(datum, basestring)
+    valid = isinstance(datum, basestring)
   elif schema_type == 'bytes':
-    return isinstance(datum, str)
+    valid = isinstance(datum, str)
   elif schema_type == 'int':
-    return ((isinstance(datum, int) or isinstance(datum, long)) 
+    valid = ((isinstance(datum, int) or isinstance(datum, long))
             and INT_MIN_VALUE <= datum <= INT_MAX_VALUE)
   elif schema_type == 'long':
-    return ((isinstance(datum, int) or isinstance(datum, long)) 
+    valid = ((isinstance(datum, int) or isinstance(datum, long))
             and LONG_MIN_VALUE <= datum <= LONG_MAX_VALUE)
   elif schema_type in ['float', 'double']:
-    return (isinstance(datum, int) or isinstance(datum, long)
+    valid = (isinstance(datum, int) or isinstance(datum, long)
             or isinstance(datum, float))
   elif schema_type == 'fixed':
-    return isinstance(datum, str) and len(datum) == expected_schema.size
+    valid = isinstance(datum, str) and len(datum) == expected_schema.size
   elif schema_type == 'enum':
-    return datum in expected_schema.symbols
+    valid = datum in expected_schema.symbols
   elif schema_type == 'array':
-    return (isinstance(datum, list) and
-      False not in [validate(expected_schema.items, d) for d in datum])
+    if isinstance(datum, list):
+      map(lambda d: validate(expected_schema.items, d), datum)
+      valid = True
   elif schema_type == 'map':
-    return (isinstance(datum, dict) and
-      False not in [isinstance(k, basestring) for k in datum.keys()] and
-      False not in
-        [validate(expected_schema.values, v) for v in datum.values()])
+    if isinstance(datum, dict):
+      map(lambda k: isinstance(k, basestring), datum.keys())
+      map(lambda v: validate(expected_schema.values, v), datum.values())
+      valid = True
   elif schema_type in ['union', 'error_union']:
-    return True in [validate(s, datum) for s in expected_schema.schemas]
+    for s in expected_schema.schemas:
+      try:
+        validate(s, datum)
+        valid = True
+      except AvroTypeException:
+        continue  # try all possible schemas
   elif schema_type in ['record', 'error', 'request']:
-    return (isinstance(datum, dict) and
-      False not in
-        [validate(f.type, datum.get(f.name)) for f in expected_schema.fields])
+    if isinstance(datum, dict):
+      for f in expected_schema.fields:
+          try:
+            validate(f.type, datum.get(f.name))
+          except AvroTypeException:
+            raise AvroTypeException(f, datum.get(f.name))
+      valid = True
+
+  if not valid:
+      raise AvroTypeException(expected_schema, datum)
 
 #
 # Decoder/Encoder
@@ -166,7 +181,7 @@ class BinaryDecoder(object):
 
   def read_boolean(self):
     """
-    a boolean is written as a single byte 
+    a boolean is written as a single byte
     whose value is either 0 (false) or 1 (true).
     """
     return ord(self.read(1)) == 1
@@ -221,7 +236,7 @@ class BinaryDecoder(object):
 
   def read_bytes(self):
     """
-    Bytes are encoded as a long followed by that many bytes of data. 
+    Bytes are encoded as a long followed by that many bytes of data.
     """
     return self.read(self.read_long())
 
@@ -286,10 +301,10 @@ class BinaryEncoder(object):
     null is written as zero bytes
     """
     pass
-  
+
   def write_boolean(self, datum):
     """
-    a boolean is written as a single byte 
+    a boolean is written as a single byte
     whose value is either 0 (false) or 1 (true).
     """
     if datum:
@@ -299,7 +314,7 @@ class BinaryEncoder(object):
 
   def write_int(self, datum):
     """
-    int and long values are written using variable-length, zig-zag coding.    
+    int and long values are written using variable-length, zig-zag coding.
     """
     self.write_long(datum);
 
@@ -343,7 +358,7 @@ class BinaryEncoder(object):
 
   def write_bytes(self, datum):
     """
-    Bytes are encoded as a long followed by that many bytes of data. 
+    Bytes are encoded as a long followed by that many bytes of data.
     """
     self.write_long(len(datum))
     self.write(struct.pack('%ds' % len(datum), datum))
@@ -385,32 +400,32 @@ class DatumReader(object):
           and w_type == r_type):
       return True
     elif (w_type == r_type == 'record' and
-          DatumReader.check_props(writers_schema, readers_schema, 
+          DatumReader.check_props(writers_schema, readers_schema,
                                   ['fullname'])):
       return True
     elif (w_type == r_type == 'error' and
-          DatumReader.check_props(writers_schema, readers_schema, 
+          DatumReader.check_props(writers_schema, readers_schema,
                                   ['fullname'])):
       return True
     elif (w_type == r_type == 'request'):
       return True
-    elif (w_type == r_type == 'fixed' and 
-          DatumReader.check_props(writers_schema, readers_schema, 
+    elif (w_type == r_type == 'fixed' and
+          DatumReader.check_props(writers_schema, readers_schema,
                                   ['fullname', 'size'])):
       return True
-    elif (w_type == r_type == 'enum' and 
-          DatumReader.check_props(writers_schema, readers_schema, 
+    elif (w_type == r_type == 'enum' and
+          DatumReader.check_props(writers_schema, readers_schema,
                                   ['fullname'])):
       return True
-    elif (w_type == r_type == 'map' and 
+    elif (w_type == r_type == 'map' and
           DatumReader.check_props(writers_schema.values,
                                   readers_schema.values, ['type'])):
       return True
-    elif (w_type == r_type == 'array' and 
+    elif (w_type == r_type == 'array' and
           DatumReader.check_props(writers_schema.items,
                                   readers_schema.items, ['type'])):
       return True
-    
+
     # Handle schema promotion
     if w_type == 'int' and r_type in ['long', 'float', 'double']:
       return True
@@ -427,7 +442,7 @@ class DatumReader(object):
     reader the "reader's schema".
     """
     self._writers_schema = writers_schema
-    self._readers_schema = readers_schema 
+    self._readers_schema = readers_schema
 
   # read/write properties
   def set_writers_schema(self, writers_schema):
@@ -438,7 +453,7 @@ class DatumReader(object):
     self._readers_schema = readers_schema
   readers_schema = property(lambda self: self._readers_schema,
                             set_readers_schema)
-  
+
   def read(self, decoder):
     if self.readers_schema is None:
       self.readers_schema = self.writers_schema
@@ -649,7 +664,7 @@ class DatumReader(object):
                  % (index_of_schema, len(writers_schema.schemas))
       raise SchemaResolutionException(fail_msg, writers_schema, readers_schema)
     selected_writers_schema = writers_schema.schemas[index_of_schema]
-    
+
     # read data
     return self.read_data(selected_writers_schema, readers_schema, decoder)
 
@@ -677,7 +692,7 @@ class DatumReader(object):
      * if the reader's record schema has a field that contains a default value,
        and writer's schema does not have a field with the same name, then the
        reader should use the default value from its field.
-     * if the reader's record schema has a field with no default value, and 
+     * if the reader's record schema has a field with no default value, and
        writer's schema does not have a field with the same name, then the
        field's value is unset.
     """
@@ -764,10 +779,7 @@ class DatumWriter(object):
                             set_writers_schema)
 
   def write(self, datum, encoder):
-    # validate datum
-    if not validate(self.writers_schema, datum):
-      raise AvroTypeException(self.writers_schema, datum)
-    
+    validate(self.writers_schema, datum)
     self.write_data(self.writers_schema, datum, encoder)
 
   def write_data(self, writers_schema, datum, encoder):
@@ -871,8 +883,11 @@ class DatumWriter(object):
     # resolve union
     index_of_schema = -1
     for i, candidate_schema in enumerate(writers_schema.schemas):
-      if validate(candidate_schema, datum):
-        index_of_schema = i
+        try:
+          validate(candidate_schema, datum)
+          index_of_schema = i
+        except AvroTypeException:
+          pass
     if index_of_schema < 0: raise AvroTypeException(writers_schema, datum)
 
     # write data

--- a/lang/py/src/avro/io.py
+++ b/lang/py/src/avro/io.py
@@ -81,9 +81,9 @@ STRUCT_CRC32 = struct_class('>I')   # big-endian unsigned int
 class AvroTypeException(schema.AvroException):
   """Raised when datum is not an example of schema."""
   def __init__(self, expected_schema, datum):
-    # pretty_expected = json.dumps(json.loads(str(expected_schema)), indent=2)
+    pretty_expected = json.dumps(json.loads(str(expected_schema)), indent=2)
     fail_msg = "The datum %s is not an example of the schema %s"\
-               % (datum, str(expected_schema))
+               % (datum, pretty_expected)
     schema.AvroException.__init__(self, fail_msg)
 
 class SchemaResolutionException(schema.AvroException):

--- a/lang/py/test/test_io.py
+++ b/lang/py/test/test_io.py
@@ -5,9 +5,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -170,7 +170,7 @@ def check_skip_number(number_type):
     if read_value == VALUE_TO_READ: correct += 1
     print ''
   return correct
-    
+
 class TestIO(unittest.TestCase):
   #
   # BASIC FUNCTIONALITY
@@ -182,7 +182,12 @@ class TestIO(unittest.TestCase):
     for example_schema, datum in SCHEMAS_TO_VALIDATE:
       print 'Schema: %s' % example_schema
       print 'Datum: %s' % datum
-      validated = io.validate(schema.parse(example_schema), datum)
+      validated = False
+      try:
+          io.validate(schema.parse(example_schema), datum)
+          validated = True
+      except io.AvroTypeException:
+          pass
       print 'Valid: %s' % validated
       if validated: passed += 1
     self.assertEquals(passed, len(SCHEMAS_TO_VALIDATE))


### PR DESCRIPTION
The existing use of `AvroTypeException` includes the full datum and schema rather than the explicit error. This changes moves the exception throwing into validate and attempts to throw with the most explicit information available.