### PR TITLE
postmates local version

### DIFF
--- a/lang/py/setup.py
+++ b/lang/py/setup.py
@@ -27,7 +27,7 @@ if version_info[:2] <= (2, 5):
 
 setup(
   name = 'avro',
-  version = '1.8.2',
+  version = '1.8.2+postmates.1',
   packages = ['avro',],
   package_dir = {'avro': 'src/avro'},
   scripts = ["./scripts/avro"],

--- a/lang/py3/setup.py
+++ b/lang/py3/setup.py
@@ -116,8 +116,6 @@ def Main():
   if not RunsFromSourceDist():
     SetupSources()
 
-  # avro_version = ReadVersion()
-
   setup(
       name = 'avro-python3',
       version = '1.8.2+postmates.1',

--- a/lang/py3/setup.py
+++ b/lang/py3/setup.py
@@ -116,11 +116,11 @@ def Main():
   if not RunsFromSourceDist():
     SetupSources()
 
-  avro_version = ReadVersion()
+  # avro_version = ReadVersion()
 
   setup(
       name = 'avro-python3',
-      version = avro_version,
+      version = '1.8.2+postmates.1',
       packages = ['avro'],
       package_dir = {'avro': 'avro'},
       scripts = ['scripts/avro'],


### PR DESCRIPTION
I'm adding a [local version identifier](https://www.python.org/dev/peps/pep-0440/#local-version-identifiers) to distinguish the Postmates forks of the python avro libraries from the upstream versions.