### PR TITLE
[dependathon] bump jetty and commons-compress

### DIFF
--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -40,7 +40,7 @@
 
     <hadoop2.version>2.7.3</hadoop2.version>
     <jackson.version>1.9.13</jackson.version>
-    <jetty.version>9.4.6.v20170531</jetty.version>
+    <jetty.version>9.4.32.v20200930</jetty.version>
     <jopt-simple.version>5.0.3</jopt-simple.version>
     <junit.version>4.12</junit.version>
     <netty.version>3.10.6.Final</netty.version>
@@ -54,7 +54,7 @@
     <ant.version>1.10.0</ant.version>
     <commons-cli.version>1.3.1</commons-cli.version>
     <commons-codec.version>1.10</commons-codec.version>
-    <commons-compress.version>1.13</commons-compress.version>
+    <commons-compress.version>1.20</commons-compress.version>
     <commons-lang.version>2.6</commons-lang.version>
     <commons-logging.version>1.2</commons-logging.version>
     <tukaani.version>1.6</tukaani.version>


### PR DESCRIPTION
dependathon doc: https://docs.google.com/document/d/1olZJEDXekdjGug84nOoH6uPEalUuWsDpeM_XgeBVOFE/edit

- jetty 9.4.6.v20170531 -> 9.4.32.v20200930
- commons-compress 1.13 -> 1.20

fixes:

CVE-2018-1324
CVE-2017-7658
CVE-2018-11771
CVE-2018-12538
CVE-2018-12536
CVE-2017-7656
CVE-2019-10246
CVE-2019-10247
CVE-2018-12545


- [ ] TODO fix jackson vulnerability but CVE-2019-10172 1.9.13 is the latest jackson available